### PR TITLE
Remove non-ASCII characters

### DIFF
--- a/model/riscv_clic_control.sail
+++ b/model/riscv_clic_control.sail
@@ -161,7 +161,7 @@ function prepare_shv_clic_trap_vector(p : Privilege, code : exc_code) -> xlenbit
 
 // Return the address for a hardware vectored CLIC xret.
 function prepare_clic_xret_vectored_target(p : Privilege) -> xlenbits = {
-  // "The trap handler function address is obtained from the current privilege mode’s
+  // "The trap handler function address is obtained from the current privilege mode's
   // xepc with the low bits of the address cleared to force the access to be naturally
   // aligned to an XLEN/8-byte table entry."
   let table_entry_addr = get_xepc(p) & ~(zero_extend(ones(log2_xlen_bytes)));

--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -118,7 +118,7 @@ function process_vset(vtype_bits_new : xlenbits, AVL : option(nat), rd : regidx)
   let vl_new = if avl <= VLMAX then to_bits(xlen, avl)
         else if avl < 2 * VLMAX then to_bits(xlen, VLMAX)
         else to_bits(xlen, VLMAX);
-  /* Note: ceil(AVL / 2) ≤ vl ≤ VLMAX when VLMAX < AVL < (2 * VLMAX)
+  /* Note: ceil(AVL / 2) <= vl <= VLMAX when VLMAX < AVL < (2 * VLMAX)
     * TODO: configuration support for either using ceil(AVL / 2) or VLMAX
     */
   X(rd) = vl_new;


### PR DESCRIPTION
There is currently a minor bug in asciidoctor-sail which means it can't load non-ASCII characters.